### PR TITLE
Update  ESP8266 pins comment in cc1101.yaml

### DIFF
--- a/cc1101.yaml
+++ b/cc1101.yaml
@@ -35,7 +35,7 @@ sensor:
 
         // esp8266 example
         D5, // SCK
-        D6, // MISO
+        D6, // MISO (sometimes labeled as GDO1)
         D7, // MOSI
         D3, // CSN
         D1, // GDO0


### PR DESCRIPTION
Some CC1101 boards do not have a "MISO" label, and it took me a while to find https://www.reddit.com/r/rfelectronics/comments/1by76tl/comment/kyhxmlo/ and figure out that it's GDO1.

This PR updates the comment so that it's going to be easier for the next person :)